### PR TITLE
Fix CMAKE_CURRENT_LIST_DIR usage in functions

### DIFF
--- a/cmake/modules/FindExtProject.cmake
+++ b/cmake/modules/FindExtProject.cmake
@@ -31,7 +31,7 @@ function(color_message text)
 endfunction()
 
 function(get_binary_package url repo repo_type repo_id exact_version is_static download_url name)
-    include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/helper.cmake)
+    include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../helper.cmake)
     get_compiler_version(COMPILER)
     get_prefix(STATIC_PREFIX ${is_static})
 
@@ -54,7 +54,7 @@ function(get_binary_package url repo repo_type repo_id exact_version is_static d
         # Get assets files.
         file(READ ${CMAKE_BINARY_DIR}/${repo}_latest.json _JSON_CONTENTS)
 
-        include(${CMAKE_CURRENT_LIST_DIR}/JSONParser.cmake)
+        include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../JSONParser.cmake)
         sbeParseJson(api_request _JSON_CONTENTS)
         foreach(asset_id ${api_request.assets})
             if(exact_version)
@@ -112,7 +112,7 @@ function(get_binary_package url repo repo_type repo_id exact_version is_static d
         # Get assets files.
         file(READ ${CMAKE_BINARY_DIR}/${repo}_latest.json _JSON_CONTENTS)
 
-        include(${CMAKE_CURRENT_LIST_DIR}/JSONParser.cmake)
+        include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../JSONParser.cmake)
         sbeParseJson(api_request _JSON_CONTENTS)
         foreach(asset_id ${api_request.files})
             string(FIND ${api_request.files_${asset_id}.name} "${STATIC_PREFIX}${COMPILER}.zip" IS_FOUND)
@@ -175,7 +175,7 @@ function(find_extproject name)
 
     # Get some properties from <cmakemodules>/FindExt${name}.cmake file.
     # This file should define repo_url, repo_type, repo, etc.
-    include(${CMAKE_CURRENT_LIST_DIR}/FindExt${name}.cmake)
+    include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/FindExt${name}.cmake)
 
     if(NOT DEFINED repo_url)
         if(repo_type STREQUAL "github")


### PR DESCRIPTION
Исправлен include скриптов.
CMAKE_CURRENT_LIST_DIR указывает на корень проекта, а не на директорию где находится FindExtProject.cmake.
Из-за этого cmake пытается подключить скрипты с корня проекта, например project/FindExtGDAL.cmake, а не  project/cmake/borsch/cmake/modules/FindExtGDAL.cmake